### PR TITLE
Update the dom result position when dom can't be all shown.

### DIFF
--- a/src/js/select.js
+++ b/src/js/select.js
@@ -123,13 +123,22 @@
              */
             this.show = function ( templateObj , keepPosition ) {
                 var pos = this.position , dom_result = this.dom_result;
-                if ( !this.config.alwaysShow && !keepPosition ) {
-                    dom_result.style.top = pos.top + 10 + 'px';
-                    dom_result.style.left = pos.left + 'px';
-                }
                 templateObj.config = $.extend( {} , this.config );
                 dom_result.innerHTML = this.render( templateObj );
                 dom_result.classList.add( 'lmk-show' );
+                if ( !this.config.alwaysShow && !keepPosition ) {
+                    dom_result.style.top = pos.top + 10 + 'px';
+                    dom_result.style.left = pos.left + 'px';
+
+                    if ( pos.top + 10 + dom_result.clientHeight > window.innerHeight && 
+                            pos.top - 10 - dom_result.clientHeight > 0 ) {
+                        dom_result.style.top = pos.top - 10 - dom_result.clientHeight + 'px';
+                    }
+                    if ( pos.left + dom_result.clientWidth > window.innerWidth && 
+                            pos.left - dom_result.clientWidth > 0 ) {
+                        dom_result.style.left = pos.left - dom_result.clientWidth + 'px';
+                    }
+                }
                 return this;
             };
             return this.show.apply( this , arguments );


### PR DESCRIPTION
问题：当翻译的单词在屏幕底下的时候显示不全，鼠标滚动翻译结果也没有跟着滚动，导致体验不好。
![1](https://cloud.githubusercontent.com/assets/2117018/7768138/bffa7b1a-00aa-11e5-9e5d-b542e0e99311.png)

修复：判断是否在屏幕内，更新显示结果。
![2](https://cloud.githubusercontent.com/assets/2117018/7768146/db210be8-00aa-11e5-8968-041d90c98bd4.png)
