### PR TITLE
让划词翻译支持 PDF 文档

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules/
-/typings/
 /src/bundle/
+/src/pdf-viewer/
 /dist/
 /coverage/
 /build.zip

--- a/build/gulp-build.js
+++ b/build/gulp-build.js
@@ -2,10 +2,11 @@ const config = {
   src : './src' ,
   dist : './dist' ,
   files : {
-    html : [ './src/*/index.html' ] ,
+    html : [ './src/*/index.html' , './src/pdf-viewer/web/viewer.html' ] ,
     json : [ './src/manifest.json' ] ,
-    js : [ './src/content-scripts/web/embed/*.js' ] ,
-    copy : [ './src/logo.png' ]
+    css : [ './src/pdf-viewer/**/*.css' ] ,
+    js : [ './src/content-scripts/web/embed/*.js' , './src/pdf-viewer/**/*.js' ] ,
+    copy : [ './src/logo.png' , './src/pdf-viewer/**/*.{bcmap,png,svg,cur,properties}' ]
   }
 };
 
@@ -14,16 +15,18 @@ const webpack = require( 'webpack' ) ,
   gulp = require( 'gulp' ) ,
   htmlmin = require( 'gulp-htmlmin' ) ,
   jsonmin = require( 'gulp-jsonmin' ) ,
+  cssmin = require('gulp-clean-css') ,
   jsmin = require( 'gulp-uglify' ) ,
   zip = require( 'gulp-zip' );
 
 gulp.task( 'clean' , clean );
 gulp.task( 'html' , [ 'clean' ] , html );
 gulp.task( 'js' , [ 'clean' ] , js );
+gulp.task( 'css' , [ 'clean' ] , css );
 gulp.task( 'json' , [ 'clean' ] , json );
 gulp.task( 'webpackP' , [ 'clean' ] , webpackP );
 gulp.task( 'copy' , [ 'clean' ] , copy );
-gulp.task( 'default' , [ 'webpackP' , 'html' , 'js' , 'json' , 'copy' ] , ( done )=> {
+gulp.task( 'default' , [ 'webpackP' , 'html' , 'js' , 'css' , 'json' , 'copy' ] , ( done )=> {
   del( config.dist + '/bundle/bs-lite.js' )
     .then( ()=> {
       zipPack().on( 'finish' , ()=> done() );
@@ -63,6 +66,12 @@ function js() {
     .pipe( gulp.dest( config.dist ) );
 }
 
+function css() {
+  return gulp.src( config.files.css , { base : config.src } )
+    .pipe(cssmin())
+    .pipe(gulp.dest('dist'));
+}
+
 /**
  * 精简 html。其实只精简了 index.html ，模板都由 webpack 负责精简。
  */
@@ -72,7 +81,8 @@ function html() {
       removeComments : true ,
       removeAttributeQuotes : true ,
       collapseWhitespace : true ,
-      processScripts : [ 'text/html' ]
+      processScripts : [ 'text/html' ],
+      minifyCSS : true
     } ) )
     .pipe( gulp.dest( config.dist ) );
 }

--- a/build/install-pdf-viewer.js
+++ b/build/install-pdf-viewer.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * 因为 pdfjs-dist.zip 内有近 400 个文件,而我不想将数量如此多的文件上传在 git 里,所以写了这个脚本自动从服务器上下载到当前项目并处理其中的文件.
+ * 详情见 https://github.com/lmk123/crx-selection-translate/issues/69
+ */
+
+const fs = require( 'fs' );
+const Download = require( 'download' );
+
+main();
+
+function main() {
+  console.log( '开始下载 pdfjs-1.3.91-dist.zip 至 ./src/pdf-viewer/ 目录……' );
+  new Download( { mode: '755', extract: true } )
+    .get( 'https://github.com/mozilla/pdf.js/releases/download/v1.3.91/pdfjs-1.3.91-dist.zip' )
+    .dest( './src/pdf-viewer' )
+    .run( function ( err ) {
+      if ( err ) {
+        throw err;
+      }
+      console.log( '下载完成.' );
+      Promise.all( [
+        deleteFiles(),
+        injectCode(),
+        removeLines()
+      ] ).then( ()=> console.log( '文件处理完成.' ) );
+    } );
+}
+
+/**
+ * 删除 pdf-viewer 中不需要的文件
+ */
+function deleteFiles() {
+  return require( 'del' )( [
+    './src/pdf-viewer/LICENSE',
+    './src/pdf-viewer/web/compressed.tracemonkey-pldi-09.pdf'
+  ] );
+}
+
+/**
+ * 给 viewer.html 注入内容脚本
+ */
+function injectCode() {
+  return new Promise( function ( resolve ) {
+    fs.readFile( './src/pdf-viewer/web/viewer.html', { encoding: 'utf8' }, ( err, data )=> {
+      if ( err ) {
+        throw err;
+      }
+
+      data = data.replace( '</body>',
+        '<link rel="stylesheet" href="../../bundle/commons1.js.css">'
+        + '<script src="../../bundle/commons3.js"></script>'
+        + '<script src="../../bundle/commons2.js"></script>'
+        + '<script src="../../bundle/commons1.js"></script>'
+        + '<script src="../../bundle/content.js"></script>'
+        + '</body>' );
+
+      fs.writeFile(
+        './src/pdf-viewer/web/viewer.html',
+        data,
+        ( err )=> {
+          if ( err ) {
+            throw err;
+          }
+          resolve();
+        } );
+    } );
+  } );
+}
+
+/**
+ * 删除 viewer.js 中判断不同源文件的代码
+ */
+function removeLines() {
+  return new Promise( ( resolve )=> {
+    fs.readFile( './src/pdf-viewer/web/viewer.js', { encoding: 'utf8' }, ( err, data )=> {
+      if ( err ) {
+        throw err;
+      }
+
+      data = data.replace( /if\s\(fileOrigin\s!==\sviewerOrigin\)\s\{[\s\S]+?\}/, '/* REMOVED */' );
+
+      fs.writeFile(
+        './src/pdf-viewer/web/viewer.js',
+        data,
+        ( err )=> {
+          if ( err ) {
+            throw err;
+          }
+          resolve();
+        } );
+    } );
+  } );
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-uglify": "^1.5.3",
     "gulp-htmlmin": "^1.3.0",
     "gulp-jsonmin": "^1.0.2",
+    "gulp-clean-css" : "^2.0.6",
     "gulp-zip": "^3.2.0",
 
     "chrome-env": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "url": "git+https://github.com/lmk123/crx-selection-translate.git"
   },
   "scripts": {
+    "postinstall": "node ./build/install-pdf-viewer",
     "dev": "webpack --config build/webpack.dev.config.js",
     "build": "gulp --cwd . --gulpfile build/gulp-build.js",
     "test": "karma start build/karma.config.js"
@@ -19,6 +20,7 @@
     "vue-router": "^0.7.11"
   },
   "devDependencies": {
+    "download": "^4.4.3",
     "babel-core": "^6.7.2",
     "babel-plugin-transform-runtime": "^6.6.0",
     "babel-polyfill": "^6.7.2",

--- a/src/background-scripts/index.js
+++ b/src/background-scripts/index.js
@@ -5,6 +5,7 @@ import './install';
 import './menus';
 import './server';
 import './badge';
+import './pdf-sniffer';
 
 import ga from '../public/ga';
 ga( 'set' , 'page' , '/background-scripts/index.html' );

--- a/src/background-scripts/install.js
+++ b/src/background-scripts/install.js
@@ -8,6 +8,7 @@ const {assign} = Object;
 
 const {runtime} = chrome ,
   defaultConfig = {
+    pdf : true , // since v6.1.0 - 是否启用 pdf 翻译
     disableSelection : false , // since v6.0.6 - 全局开关
     disableInEditable : false , // since v6.0.1 - 是否在 document.body 可编辑的情况下禁用划词翻译
     defaultWeb : 'youdao' , // since v6.0.1 - Alt + Z 时默认使用的网页翻译
@@ -99,6 +100,14 @@ export async function onInstalled( details ) {
       case '6.0.4':
       case '6.0.5':
         addNewOptions( 'disableSelection' );
+      case '6.0.6':
+      case '6.0.7':
+      case '6.0.8':
+      case '6.0.9':
+      case '6.0.10':
+      case '6.0.11':
+      case '6.0.12':
+        addNewOptions( 'pdf' );
       // 这里故意没有写 break;
       // 这是因为如果日后的版本添加了新的设置项可以这样写：
       // case '6.0.0':

--- a/src/background-scripts/pdf-sniffer.js
+++ b/src/background-scripts/pdf-sniffer.js
@@ -1,50 +1,124 @@
+// todo 代码里注释掉了使用 webNavigation 捕捉 file:// 协议的代码,
+// 因为新增一个 webNavigation 会导致更新后被 Chrome 停用的情况,
+// 需要使用 optional permissions
+// @see https://developer.chrome.com/extensions/permissions
+
 import watcher from '../public/storage-watcher';
 import chromeCall from 'chrome-call';
 
+const { webRequest, webNavigation } = chrome;
+
 const viewerPath = chrome.runtime.getURL( '/pdf-viewer/web/viewer.html' );
 
-export function redirect2viewer( details ) {
+function getViewerURL( pdfUrl ) {
+  return viewerPath + '?file=' + encodeURIComponent( pdfUrl );
+}
+
+/**
+ * ftp:// 协议直接跳转到 viewer 就好
+ * @param details
+ * @returns {chrome.webRequest.BlockingResponse}
+ */
+export function onBeforeRequestForFTP( details ) {
   return {
-    redirectUrl: viewerPath + '?file=' + encodeURIComponent( details.url )
+    redirectUrl: getViewerURL( details.url )
   };
+}
+
+/**
+ * http(s) 协议需要通过响应头判断响应是否是一个 PDF 文档
+ * @param details
+ * @returns {chrome.webRequest.BlockingResponse}
+ */
+export function onHeadersReceivedForHTTP( details ) {
+  if ( details.method !== 'GET' ) {
+    return;
+  }
+
+  let contentType;
+  details.responseHeaders.some( ( h )=> {
+    if ( h.name.toLowerCase() === 'content-type' ) {
+      contentType = h.value;
+      return true;
+    }
+  } );
+  if ( !contentType ) {
+    return;
+  }
+
+  contentType = contentType.toLowerCase().split( ';', 1 )[ 0 ].trim();
+  if ( contentType === 'application/pdf' ||
+    contentType === 'application/octet-stream' &&
+    details.url.toLowerCase().indexOf( '.pdf' ) > 0 ) {
+    return {
+      redirectUrl: getViewerURL( details.url )
+    };
+  }
+}
+
+/**
+ * webRequest 不会捕捉 file:// 协议,只能使用 webNavigation 了
+ * @param details
+ */
+export function onBeforeNavigateForFile( details ) {
+  if ( details.frameId === 0 ) {
+    chrome.tabs.update( details.tabId, {
+      url: getViewerURL( details.url )
+    } );
+  }
 }
 
 export let enabled = false;
 
+// 开启 pdf 翻译
 function enable() {
   if ( enabled ) {
     return;
   }
   enabled = true;
-  chrome.webRequest.onBeforeRequest.addListener(
-    redirect2viewer,
+  webRequest.onBeforeRequest.addListener(
+    onBeforeRequestForFTP,
     {
       urls: [
-        '*://*/*.pdf',
-        '*://*/*.PDF'
+        'ftp://*/*.pdf',
+        'ftp://*/*.PDF'
       ],
       types: [ 'main_frame', 'sub_frame' ]
     },
     [ 'blocking' ]
   );
+
+  webRequest.onHeadersReceived.addListener(
+    onHeadersReceivedForHTTP,
+    {
+      urls: [ 'http://*/*', 'https://*/*' ],
+      types: [ 'main_frame', 'sub_frame' ]
+    },
+    [ 'blocking', 'responseHeaders' ]
+  );
+
+  // webNavigation.onBeforeNavigate.addListener( onBeforeNavigateForFile, {
+  //   url: [
+  //     {
+  //       urlPrefix: 'file://',
+  //       pathSuffix: '.pdf'
+  //     }, {
+  //       urlPrefix: 'file://',
+  //       pathSuffix: '.PDF'
+  //     }
+  //   ]
+  // } );
 }
 
+// 关闭 pdf 翻译
 function disable() {
   if ( !enabled ) {
     return;
   }
   enabled = false;
-  chrome.webRequest.onBeforeRequest.removeListener(
-    redirect2viewer,
-    {
-      urls: [
-        '*://*/*.pdf',
-        '*://*/*.PDF'
-      ],
-      types: [ 'main_frame', 'sub_frame' ]
-    },
-    [ 'blocking' ]
-  );
+  webRequest.onBeforeRequest.removeListener( onBeforeRequestForFTP );
+  webRequest.onHeadersReceived.removeListener( onHeadersReceivedForHTTP );
+  // webNavigation.onBeforeNavigate.removeListener( onBeforeNavigateForFile );
 }
 
 function onStorageChanged( items ) {

--- a/src/background-scripts/pdf-sniffer.js
+++ b/src/background-scripts/pdf-sniffer.js
@@ -1,0 +1,63 @@
+import watcher from '../public/storage-watcher';
+import chromeCall from 'chrome-call';
+
+const viewerPath = chrome.runtime.getURL( '/pdf-viewer/web/viewer.html' );
+
+export function redirect2viewer( details ) {
+  return {
+    redirectUrl: viewerPath + '?file=' + encodeURIComponent( details.url )
+  };
+}
+
+export let enabled = false;
+
+function enable() {
+  if ( enabled ) {
+    return;
+  }
+  enabled = true;
+  chrome.webRequest.onBeforeRequest.addListener(
+    redirect2viewer,
+    {
+      urls: [
+        '*://*/*.pdf',
+        '*://*/*.PDF'
+      ],
+      types: [ 'main_frame', 'sub_frame' ]
+    },
+    [ 'blocking' ]
+  );
+}
+
+function disable() {
+  if ( !enabled ) {
+    return;
+  }
+  chrome.webRequest.onBeforeRequest.removeListener(
+    redirect2viewer,
+    {
+      urls: [
+        '*://*/*.pdf',
+        '*://*/*.PDF'
+      ],
+      types: [ 'main_frame', 'sub_frame' ]
+    },
+    [ 'blocking' ]
+  );
+}
+
+function onStorageChanged( items ) {
+  console.log( items );
+  if ( items.pdf ) {
+    enable();
+  } else {
+    disable();
+  }
+}
+
+/* istanbul ignore if */
+if ( process.env.NODE_ENV !== 'testing' ) {
+  watcher( 'pdf', 'local', onStorageChanged );
+  chromeCall( 'storage.local.get', { pdf: true } )
+    .then( onStorageChanged );
+}

--- a/src/background-scripts/pdf-sniffer.js
+++ b/src/background-scripts/pdf-sniffer.js
@@ -33,6 +33,7 @@ function disable() {
   if ( !enabled ) {
     return;
   }
+  enabled = false;
   chrome.webRequest.onBeforeRequest.removeListener(
     redirect2viewer,
     {
@@ -47,7 +48,6 @@ function disable() {
 }
 
 function onStorageChanged( items ) {
-  console.log( items );
   if ( items.pdf ) {
     enable();
   } else {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,9 @@
     "clipboardWrite" ,
     "clipboardRead" ,
     "activeTab" ,
-    "identity"
+    "identity",
+    "webRequest",
+    "webRequestBlocking"
   ] ,
   "background" : {
     "scripts" : [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   } ,
   "author" : "Milk Lee <milk.lee@qq.com>" ,
   "permissions" : [
-    "*://*/*" ,
+    "<all_urls>" ,
     "contextMenus" ,
     "storage" ,
     "clipboardWrite" ,

--- a/src/options/settings/template.html
+++ b/src/options/settings/template.html
@@ -46,6 +46,12 @@
       打开翻译盒子时，自动翻译剪切板内的文本
     </label>
   </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" v-model="options.pdf">
+      开启 PDF 翻译功能
+    </label>
+  </div>
 </div>
 
 <h4>翻译筛选</h4>


### PR DESCRIPTION
刚才我花了点时间找到了让划词翻译支持 PDF 文件的方法，在这里记录一下。

首先要说明的是，官方提供的结合 Webpack 使用的例子只能将 PDF 转换为 canvas，划词翻译还是没法使用，所以我需要的其实是 pdf.js 里的 viewer。

### 详细步骤

 1. 在 https://github.com/mozilla/pdf.js/releases/tag/v1.3.91 下载 `pdfjs-1.3.91-dist.zip` 并解压到 `./src` 的 `pdfjs-1.3.91-dist` 目录下
 2. 打开 `./src/pdfjs-1.3.91-dist/web/viewer.js`，注释掉其中的第 7157-7159 行。这是为了避免 view.js 在检测到不同源的 PDF 文档时报错——在 Chrome 扩展程序里是可以进行跨域请求的。
 3. 打开 `./src/pdfjs-1.3.91-dist/web/viewer.html`，并在 `</body>` 前加上下面几行代码：

```html
<link rel="stylesheet" href="../../bundle/commons1.js.css">
<script src="../../bundle/commons3.js"></script>
<script src="../../bundle/commons2.js"></script>
<script src="../../bundle/commons1.js"></script>
<script src="../../bundle/content.js"></script>
```

现在，在浏览器内打开 `chrome-extension://bocneeaaedgmgcehokhbgffchgbbhllk/pdfjs-1.3.91-dist/web/viewer.html?file=http%3A%2F%2Fmozilla.github.io%2Fpdf.js%2Fweb%2Fcompressed.tracemonkey-pldi-09.pdf` 就能预览 http://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf 的 PDF 文件，并且划词翻译能正常工作。

### 工作原理

 1. 要让划词翻译能翻译 PDF 内的文本，首先要使用 pdf.js 自带的 viewer 打开 PDF 文档。
 2. 然后，因为内容脚本不会被插入到 `chrome-extension://*` 类的网页里，所以要手动在 viewer.html 底部加上内容脚本的代码。
 3. 最后，在打开 viewer.html 的网址后加上 `?file=pdf文件的URL`（pdf 文件的 URL 需要使用 `encodeURIComponent()` 编码），viewer.html 就会加载 PDF 文件了。

### 需要解决的问题

 - `pdfjs-1.3.91-dist.zip` 里有近 400 个文件，但需要改动的只有两个文件，所以我需要使用编程的方式将它下载到项目中及改动文件（使用 `postinstall`）。
 - 需要在检测到即将访问一个 PDF 文档时跳转到 viewer.html 并带上 PDF 文档的 URL。可以在内容脚本内判断当前 URL 是否以 `.pdf` 结尾，或者使用 [chrome.webRequest](https://developer.chrome.com/extensions/webRequest#event-onBeforeRequest) 检测（后者好些）

此 PR 就解决了上面的两个问题。相关 issue：#69